### PR TITLE
User data to moved to sdram

### DIFF
--- a/FreeRTOS/FreeRTOSConfig.h
+++ b/FreeRTOS/FreeRTOSConfig.h
@@ -66,16 +66,10 @@
 #define configUSE_COUNTING_SEMAPHORES           1
 #define configSUPPORT_STATIC_ALLOCATION         1
 
-#ifndef configAPPLICATION_ALLOCATED_HEAP
-#define configAPPLICATION_ALLOCATED_HEAP        1   
-#endif
-
 /**
  * @brief FreeRtos heap declaration
- * First attribute puts heap into sdram
- * Second suppresses warnings
  */
-__attribute__((section(".sdramMemorySection"), unused))
+__attribute__((unused))
 static uint8_t ucHeap[configTOTAL_HEAP_SIZE] = { 0 };
 
 /* The full demo always has tasks to run so the tick will never be turned off.


### PR DESCRIPTION
All of the user data is statically allocated on the SDRAM. Therefore, there is no need to force the FreeRTOS heap to be located at SDRAM.