### PR TITLE
Bugfix in Hal.c.Uart_startup called before Uart_init

### DIFF
--- a/src/Hal/Hal.c
+++ b/src/Hal/Hal.c
@@ -229,8 +229,8 @@ Hal_uart_init(Hal_Uart* const halUart, Hal_Uart_Config halUartConfig)
     Hal_uart_init_pio(halUartConfig.id);
     Hal_uart_init_nvic(halUartConfig.id);
 
-    Uart_startup(&halUart->uart);
     Uart_init(halUartConfig.id, &halUart->uart);
+    Uart_startup(&halUart->uart);
 
     Uart_Config config = { .isTxEnabled = true,
                            .isRxEnabled = true,


### PR DESCRIPTION
There was a bug that became apparent only after using SDRAM for a serial_ccsds_data structure. The startup function that uses a UARTregister was called before initializing the address of the UART register. When the structure is allocated on the SRAM, the address is zero, and nothing happens. It is probably due to pure luck or undefined behavior. When the structure is on the SDRAM and there was no power cycling on the board since the last run, the address might be non-zero as there might be an old value in the SDRAM. It caused a segmentation fault, due to unaligned memory access. 